### PR TITLE
Change helpers to classes instead of ids, remove inline styles.

### DIFF
--- a/lib/client/meteor.paginator.js
+++ b/lib/client/meteor.paginator.js
@@ -51,7 +51,7 @@ Meteor.Paginator = function(_opts) {
 				_scheduledPage = parseInt(ele.attr("data-page")) || 0; //zero if pagination is missing
 				break;
 		}
-		
+
 		if (opts.pagination.currentPage !== _scheduledPage) {
     		opts.pagination.currentPage = _scheduledPage;
     		var skip = _scheduledPage * opts.pagination.resultsPerPage, limit = opts.pagination.resultsPerPage;
@@ -80,7 +80,7 @@ Meteor.Paginator = function(_opts) {
 	    		_btns.push({ r: p, p: p + 1, instance: _instance });
 	    	}
     	}
-		
+
     	Session.set(_sessionMultiplePages, opts.pagination.totalPages);
     	Session.set(_sessionButtons, _btns);
 	};
@@ -110,7 +110,7 @@ Meteor.Paginator = function(_opts) {
 			opts.pagination.totalRecords = tot;
 			_setPagination();
 			_renderButtons();
-			opts.callbacks.onPagingCompleted && opts.callbacks.onPagingCompleted(0, opts.pagination.resultsPerPage);		
+			opts.callbacks.onPagingCompleted && opts.callbacks.onPagingCompleted(0, opts.pagination.resultsPerPage);
 		});
 	};
 
@@ -148,11 +148,11 @@ Meteor.Paginator = function(_opts) {
 					"<li><a href='javascript:' data-page='last' class='pageButton' data-instance-id='{instance}'><i class='fa fa-angle-double-right'></i></a></li>" +
 				"</ul>"
 		, indiv: "<li><a href='javascript:' data-page='{r}' class='pageButton' data-instance-id='{instance}'>{p}</a></li>"
-		, rpp:  "<div class='pull-left margin-7'>" +
+		, rpp:  "<div class='pull-left'>" +
 				"	<small>records per page:</small>" +
 				"</div>" +
 				"<div class='pull-left'>" +
-				"	<select id='selectPerPage' class='form-control input-sm' style='font-size:10pt;' data-instance-id='{instance}'> " + 
+				"	<select id='selectPerPage' class='form-control' data-instance-id='{instance}'> " +
 				"		<option value='5'>5</option>" +
 				"		<option value='10'>10</option>" +
 				"		<option value='20'>20</option>" +
@@ -180,17 +180,17 @@ Meteor.Paginator = function(_opts) {
 			_html = _html.replace(/{buttons}/gi, _btns.join(""));
 
 			window.setTimeout(function() {
-				if ($("#paging_buttons_" + _instance).length > 0) {
+				if ($(".paging_buttons_" + _instance).length > 0) {
 					//window.clearInterval(_rb);
-					$("#paging_buttons_" + _instance).html(_html);
+					$(".paging_buttons_" + _instance).html(_html);
 					window.setTimeout(_setBtnStyles(), 10);
 				} else {
-					console.log("****PAGINATION BUG: could not find #paging_buttons_" + _instance);
+					console.log("****PAGINATION BUG: could not find .paging_buttons_" + _instance);
 				}
 			}, 500);
-			
+
 		} else {
-			$("#paging_buttons_" + _instance).html("");
+			$(".paging_buttons_" + _instance).html("");
 		}
 	};
 
@@ -229,7 +229,7 @@ Meteor.Paginator = function(_opts) {
 						_renderButtons();
 					}, 1);
 				}
-				return "<span id='paging_buttons_" + _instance + "'></span>";
+				return "<span class='paging_buttons_" + _instance + "'></span>";
 			},
 			selectPerPage: function() {
 				window.setTimeout(function() { _renderRpp() }, 100);
@@ -243,7 +243,7 @@ Meteor.Paginator = function(_opts) {
 			// window.setTimeout(function() {
 			// 	_renderButtons();
 			// }, 1);
-			return "<span id='paging_buttons_" + _instance + "'></span>";
+			return "<span class='paging_buttons_" + _instance + "'></span>";
 		};
 
 		Template[opts.templates.content].selectPerPage = function() {
@@ -253,7 +253,7 @@ Meteor.Paginator = function(_opts) {
 
 	}
 
-	
+
 
 	// Template.pagination_buttons.instance = function() {
 	// 	return _instance;
@@ -264,7 +264,7 @@ Meteor.Paginator = function(_opts) {
 	// };
 
 	// Template.select_per_page.rendered = function() {
-		
+
 	// };
 
 	// Template.pagination_buttons.hasMultiplePages = function() {
@@ -282,7 +282,7 @@ Meteor.Paginator = function(_opts) {
 
 	Template[opts.templates.content].destroyed = function() {
 		opts.callbacks.onTemplateDestroyed && opts.callbacks.onTemplateDestroyed();
-		setTimeout(function() {	
+		setTimeout(function() {
 			delete Session.keys[_sessionMultiplePages];
 			delete Session.keys[_sessionButtons];
 			delete _self;


### PR DESCRIPTION
Hey Tim, by changing the selectors from ids to classes, we're able to use the {{{pagingButtons}}} helper more than just once in a template.
